### PR TITLE
add bs_email_count_total for multiple email statuses

### DIFF
--- a/Application Tests/opentelementry/manual-implementation/golang-broadside-demo/new_main/constants/email-constants.go
+++ b/Application Tests/opentelementry/manual-implementation/golang-broadside-demo/new_main/constants/email-constants.go
@@ -1,0 +1,12 @@
+package constants
+
+import "go.opentelemetry.io/otel/attribute"
+
+// Custom attribute keys for our metrics.
+const (
+	DCSKey      = attribute.Key("dcs")
+	StateKey    = attribute.Key("state")
+	ProviderKey = attribute.Key("provider")
+	StatusKey   = attribute.Key("status")
+	APP_PORT    = ":8088"
+)

--- a/Application Tests/opentelementry/manual-implementation/golang-broadside-demo/new_main/main.go
+++ b/Application Tests/opentelementry/manual-implementation/golang-broadside-demo/new_main/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"example.com/test/new_main/constants"
+	"example.com/test/new_main/service"
+	"example.com/test/new_main/utils"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	// Using v1.21.0 as specified
+)
+
+// emailCounter is the global metric counter for emails.
+var (
+	//emailCounter metric.Int64Counter
+	serviceIP   = utils.GetOutboundIP()
+	serviceName = "broadside-email-service"
+)
+
+func main() {
+
+	ctx := context.Background()
+
+	log.Printf("Starting email-service with instance ID: %s", serviceIP)
+
+	// Initialize OpenTelemetry metrics with service-level attributes.
+	provider, err := service.InitMetrics(serviceName, serviceIP)
+	if err != nil {
+		log.Fatalf("Failed to initialize metrics: %v", err)
+	}
+
+	// Ensure the MeterProvider is shut down when main exits
+	defer func() {
+		if err := provider.Shutdown(ctx); err != nil {
+			log.Printf("Error shutting down MeterProvider: %v", err)
+		}
+	}()
+	//go service.Test()
+	service.SimulateMetrics(ctx)
+
+	// Set up the HTTP server to expose Prometheus metrics.
+	http.Handle("/metrics", promhttp.Handler())
+	log.Println("Prometheus metrics server listening on " + constants.APP_PORT + "/metrics")
+
+	log.Fatal(http.ListenAndServe(constants.APP_PORT, nil))
+}

--- a/Application Tests/opentelementry/manual-implementation/golang-broadside-demo/new_main/model/response/email.go
+++ b/Application Tests/opentelementry/manual-implementation/golang-broadside-demo/new_main/model/response/email.go
@@ -1,0 +1,43 @@
+package model
+
+type SolrResponse struct {
+	ResponseHeader ResponseHeader `json:"responseHeader"`
+	Response       Response       `json:"response"`
+	FacetCounts    FacetCounts    `json:"facet_counts"`
+}
+
+type ResponseHeader struct {
+	ZKConnected bool        `json:"zkConnected"`
+	Status      int         `json:"status"`
+	QTime       int         `json:"QTime"`
+	Params      QueryParams `json:"params"`
+}
+
+type QueryParams struct {
+	Query      string `json:"q"`
+	FacetField string `json:"facet.field"`
+	Start      string `json:"start"`
+	Rows       string `json:"rows"`
+	Facet      string `json:"facet"`
+	WriterType string `json:"wt"`
+}
+
+type Response struct {
+	NumFound      int           `json:"numFound"`
+	Start         int           `json:"start"`
+	MaxScore      float64       `json:"maxScore"`
+	NumFoundExact bool          `json:"numFoundExact"`
+	Docs          []interface{} `json:"docs"`
+}
+
+type FacetCounts struct {
+	FacetQueries   map[string]interface{} `json:"facet_queries"`
+	FacetFields    FacetFields            `json:"facet_fields"`
+	FacetRanges    map[string]interface{} `json:"facet_ranges"`
+	FacetIntervals map[string]interface{} `json:"facet_intervals"`
+	FacetHeatmaps  map[string]interface{} `json:"facet_heatmaps"`
+}
+
+type FacetFields struct {
+	BMLStatus []interface{} `json:"bml_status"`
+}

--- a/Application Tests/opentelementry/manual-implementation/golang-broadside-demo/new_main/service/email-service.go
+++ b/Application Tests/opentelementry/manual-implementation/golang-broadside-demo/new_main/service/email-service.go
@@ -1,0 +1,145 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"example.com/test/new_main/constants"
+	model "example.com/test/new_main/model/response"
+	"example.com/test/new_main/utils"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+)
+
+var (
+	emailCounter metric.Int64Counter
+	serviceIP    = utils.GetOutboundIP()
+	serviceName  = "broadside-email-service"
+)
+
+func Test(ctx context.Context) {
+
+	now := time.Now().UTC()
+	start_time := now.Add(-1 * time.Hour)
+	end_time := now
+	start_time_str := start_time.Format(time.RFC3339)
+	end_time_str := end_time.Format(time.RFC3339)
+	query := fmt.Sprintf("bml_dispatchedat:[%s TO %s]", start_time_str, end_time_str)
+
+	resp, err := http.Get("https://reqres.in/api/users?page=2")
+
+	if err != nil {
+		panic(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+
+	var request model.SolrResponse
+	if err := json.Unmarshal(body, &request); err != nil {
+		panic(err)
+	}
+
+	request.ResponseHeader.Params.Query = query
+	log.Println(resp.Body)
+	//dcs:=
+
+	dcsOptions := []string{"dcs1", "lsp", "lsh"}
+	providerOptions := []string{"gmail", "hotmail", "outlook", "rediffmail", "others"}
+
+	//time.Sleep(15 * time.Second)
+	// Choose random label values for each attribute.
+	dcs := dcsOptions[rand.Intn(len(dcsOptions))]
+	state := rand.Intn(100)
+	provider := providerOptions[rand.Intn(len(providerOptions))]
+
+	//bml_status_map := utils.ConvertBMLStatus(request.FacetCounts.FacetFields.BMLStatus)
+
+	statusCountMap := map[string]int{
+		"in_transit": 13,
+		"sent":       12,
+		"bounced":    10,
+		"rejected":   033,
+	}
+	bml_status_map := statusCountMap
+	// var transit_count, sent_count, bounced_count, rejected_count, total int64
+	// var transit_status, sent_status, bounced_status, rejected_status, total_status string
+	total := int64(request.Response.NumFound)
+	total_status := "total"
+	bml_status_map[total_status] = int(total)
+	fmt.Println(bml_status_map)
+
+	for status, count := range bml_status_map {
+
+		emailCounter.Add(ctx, int64(count),
+			// 6. Define the service's resource attributes.
+			// These describe the service itself and are attached to all metrics produced by MeterProvider.
+			metric.WithAttributes(
+				semconv.ServiceNameKey.String(serviceName),
+				semconv.ServiceInstanceIDKey.String(serviceIP),
+				constants.DCSKey.String(dcs),
+				constants.StateKey.Int(state),
+				constants.ProviderKey.String(provider),
+				constants.StatusKey.String(status),
+			),
+		)
+	}
+
+}
+
+// SimulateMetrics generates random email events and adds them to the counter.
+func SimulateMetrics(ctx context.Context) {
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return // Exit goroutine if context is cancelled
+			default:
+
+				Test(ctx)
+
+				// Simulate work/delay before the next event.
+				time.Sleep(15 * time.Second)
+			}
+		}
+	}()
+}
+
+// initMetrics initializes the OpenTelemetry MeterProvider and Prometheus exporter.
+func InitMetrics(serviceName, serviceInstanceID string) (*sdkmetric.MeterProvider, error) {
+	// 1. Configure the Prometheus exporter.
+	exporter, err := prometheus.New()
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Create the MeterProvider with the exporter and resource.
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(exporter),
+	)
+
+	// 3. Get a Meter from the provider.
+	meter := provider.Meter("bs.email.meter") // Use a unique name for your meter
+
+	// 4. Create the Int64Counter metric.
+	emailCounter, err = meter.Int64Counter(
+		"bs_email_count",
+		metric.WithDescription("Counts emails based on dcs, state, provider, and status"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// 5. Register the MeterProvider globally.
+	otel.SetMeterProvider(provider)
+
+	return provider, nil
+}

--- a/Application Tests/opentelementry/manual-implementation/golang-broadside-demo/new_main/utils/email.go
+++ b/Application Tests/opentelementry/manual-implementation/golang-broadside-demo/new_main/utils/email.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strings"
+)
+
+func ConvertBMLStatus(raw []interface{}) map[string]int {
+	result := make(map[string]int)
+	for i := 0; i < len(raw); i += 2 {
+		key, _ := raw[i].(string)
+		value, _ := raw[i+1].(float64) // JSON numbers are decoded as float64
+		result[key] = int(value)
+	}
+	return result
+}
+
+func ExtractStartAndEndTime(query string) (string, string) {
+
+	start := strings.Index(query, "[")
+	end := strings.Index(query, "]")
+
+	if start != -1 && end != -1 {
+		timeRange := query[start+1 : end] // Extracts 2025-05-25T00:00:00Z TO 2025-05-25T23:59:59Z
+		parts := strings.Split(timeRange, " TO ")
+		if len(parts) == 2 {
+			fromTime := parts[0]
+			toTime := parts[1]
+			fmt.Println("From:", fromTime)
+			fmt.Println("To  :", toTime)
+			return fromTime, toTime
+		}
+	}
+	return "", ""
+
+}
+
+// getOutboundIP attempts to determine the system's preferred outbound IP address.
+func GetOutboundIP() string {
+	conn, err := net.Dial("udp", "8.8.8.8:80") // Connect to a public DNS server (no data sent)
+	if err != nil {
+		log.Printf("Warning: Could not determine outbound IP. Using 'unknown_ip'. Error: %v", err)
+		return "unknown_ip"
+	}
+	defer conn.Close() // Ensure the connection is closed
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	return localAddr.IP.String()
+}
+
+


### PR DESCRIPTION
-Added bs_email_count_total for multiple email statuses
-Dynamically populate metric using values from bml_status map
- Added support for statuses: sent, bounced, rejected, in_transit
- Attached relevant service and email metadata as metric attributes

